### PR TITLE
updated the users table migration

### DIFF
--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -12,14 +12,19 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->id();
-            $table->string('name');
+            $table->id('user_id');
+            $table->string('username')->unique();
+            $table->string('password_hash');
             $table->string('email')->unique();
-            $table->enum('role', ['admin', 'customer'])->default('customer');
-            $table->timestamp('email_verified_at')->nullable();
-            $table->string('password');
-            $table->rememberToken();
-            $table->timestamps();
+            $table->enum('user_type', ['admin', 'customer'])->default('customer');
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('last_login')->nullable();
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->text('address');
+            $table->string('phone_number'); 
+            $table->integer('credits')->default(0);
+            
         });
 
         Schema::create('password_reset_tokens', function (Blueprint $table) {


### PR DESCRIPTION
- Updated the users table migration based on the provided schema:
  - Added all fields (user_id, username, password_hash, email, user_type, created_at, last_login, first_name, last_name, address, phone_number, credits)
  - Ensured username and email are unique
  - Used enum for user_type to restrict roles to admin and customer (default set to customer)
  - Set credits default to 0.

Note: The last_login field is currently nullable, and I will implement logic to update it automatically later.